### PR TITLE
composer require fixed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ $ pecl install swoole
 Installation of CrowPHP via composer, the following command will install the framework and all of its dependencies with it.
 
 ```
-composer install crowphp/crow
+composer require crowphp/crow
 ```
 
 ### Hello world microservice using CrowPHP


### PR DESCRIPTION
composer install command does not accept specific packages,  `composer install crowphp/crow`  renamed to `composer require crowphp/crow`